### PR TITLE
Provide a meaningful response from the 'join' endpoint if nickname missing

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -63,7 +63,12 @@ curl <IP & PORT>/v1/games/create
 
 * **Error Response:**
   
-  * **Code:** 403 FORBIDDEN <br />
+  * **Code:** 400 BAD REQUEST <br />
+  **Content:** `{"error":"Nickname missing - please supply it"}`
+
+  OR
+  
+* **Code:** 403 FORBIDDEN <br />
   **Content:** `{"error":"The game room is full"}`
 
   OR

--- a/api/endpoints.R
+++ b/api/endpoints.R
@@ -44,7 +44,13 @@ function(res) {
 #* @param nickname The nickname chosen by the user.
 #* @get /v1/games/<game_uuid>/join
 function(game_uuid, nickname, res) {
-
+  
+  # Check if the nickname argument has been supplied
+  if(missing(nickname)) {
+    res$status <- 400
+    return(list(error = "Nickname missing - please supply it"))
+  }
+  
   # Check if the supplied game UUID is a valid UUID before loading the game
   game_uuid_valid <- validate_uuid(game_uuid)
   if(!game_uuid_valid) {


### PR DESCRIPTION
Closes #32 

The presence of parameters in other functions and the acceptability of a nickname will be checked as part of another issue.